### PR TITLE
Changes to support history - EAC-20

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/eas/api/constants/EventType.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/constants/EventType.java
@@ -1,6 +1,9 @@
 package ca.bc.gov.educ.eas.api.constants;
 
 public enum EventType {
+  INITIATED, //Default. Used by BaseOrchestrator.
+  MARK_SAGA_COMPLETE, //Default. Used by BaseOrchestrator.
+  GET_PAGINATED_SCHOOLS,
   CREATE_STUDENT_REGISTRATION,
   GET_STUDENT_REGISTRATION
 }

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/model/v1/AssessmentStudentHistoryEntity.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/model/v1/AssessmentStudentHistoryEntity.java
@@ -1,0 +1,75 @@
+package ca.bc.gov.educ.eas.api.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.PastOrPresent;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Builder
+@Table(name = "ASSESSMENT_STUDENT_HISTORY")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AssessmentStudentHistoryEntity {
+
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @UuidGenerator
+    @Column(name = "ASSESSMENT_STUDENT_HISTORY_ID", unique = true, updatable = false, columnDefinition = "BINARY(16)")
+    private UUID assessmentStudentHistoryID;
+
+    @Basic
+    @Column(name = "ASSESSMENT_STUDENT_ID", columnDefinition = "BINARY(16)")
+    private UUID assessmentStudentID;
+
+    @Basic
+    @Column(name = "ASSESSMENT_ID", columnDefinition = "BINARY(16)")
+    private UUID assessmentID;
+
+    @Column(name = "SCHOOL_ID", nullable = false, columnDefinition = "BINARY(16)")
+    private UUID schoolID;
+
+    @Column(name = "STUDENT_ID", nullable = false, columnDefinition = "BINARY(16)")
+    private UUID studentID;
+
+    @Column(name = "PEN", nullable = false, length = 9)
+    private String pen;
+
+    @Column(name = "LOCAL_ID", length = 12)
+    private String localID;
+
+    @Column(name = "IS_ELECTRONIC_EXAM", length = 1)
+    private Boolean isElectronicExam;
+
+    @Column(name = "FINAL_PERCENTAGE", length = 3)
+    private String finalPercentage;
+
+    @Column(name = "PROVINCIAL_SPECIAL_CASE_CODE", length = 1)
+    private String provincialSpecialCaseCode;
+
+    @Column(name = "COURSE_STATUS_CODE", length = 1)
+    private String courseStatusCode;
+
+    @Column(name = "CREATE_USER", updatable = false, length = 100)
+    private String createUser;
+
+    @PastOrPresent
+    @Column(name = "CREATE_DATE", updatable = false)
+    private LocalDateTime createDate;
+
+    @Column(name = "UPDATE_USER", length = 100)
+    private String updateUser;
+
+    @PastOrPresent
+    @Column(name = "UPDATE_DATE")
+    private LocalDateTime updateDate;
+}

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/repository/v1/AssessmentStudentHistoryRepository.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/repository/v1/AssessmentStudentHistoryRepository.java
@@ -1,0 +1,12 @@
+package ca.bc.gov.educ.eas.api.repository.v1;
+
+import ca.bc.gov.educ.eas.api.model.v1.AssessmentStudentHistoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AssessmentStudentHistoryRepository extends JpaRepository<AssessmentStudentHistoryEntity, UUID> {
+    List<AssessmentStudentHistoryEntity> findAllByAssessmentIDAndAssessmentStudentID(UUID asessmentID, UUID assessmentStudentID);
+
+}

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/repository/v1/AssessmentStudentRepository.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/repository/v1/AssessmentStudentRepository.java
@@ -2,7 +2,6 @@ package ca.bc.gov.educ.eas.api.repository.v1;
 
 
 import ca.bc.gov.educ.eas.api.model.v1.AssessmentStudentEntity;
-import ca.bc.gov.educ.eas.api.model.v1.EasEventEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
@@ -12,5 +11,5 @@ import java.util.UUID;
 
 @Repository
 public interface AssessmentStudentRepository extends JpaRepository<AssessmentStudentEntity, UUID>, JpaSpecificationExecutor<AssessmentStudentEntity> {
-    Optional<AssessmentStudentEntity> findByAssessmentIDAndStudentID(UUID assessmentID, String studentID);
+    Optional<AssessmentStudentEntity> findByAssessmentEntity_AssessmentIDAndStudentID(UUID assessmentID, UUID studentID);
 }

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/AssessmentStudentHistoryService.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/AssessmentStudentHistoryService.java
@@ -1,0 +1,29 @@
+package ca.bc.gov.educ.eas.api.service.v1;
+
+import ca.bc.gov.educ.eas.api.model.v1.AssessmentStudentEntity;
+import ca.bc.gov.educ.eas.api.model.v1.AssessmentStudentHistoryEntity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Slf4j
+public class AssessmentStudentHistoryService {
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public AssessmentStudentHistoryEntity createAssessmentStudentHistoryEntity(AssessmentStudentEntity assessmentStudentEntity, String updateUser) {
+        final AssessmentStudentHistoryEntity assessmentStudentHistoryEntity = new AssessmentStudentHistoryEntity();
+        BeanUtils.copyProperties(assessmentStudentEntity, assessmentStudentHistoryEntity);
+        assessmentStudentHistoryEntity.setAssessmentStudentID(assessmentStudentEntity.getAssessmentStudentID());
+        assessmentStudentHistoryEntity.setAssessmentID(assessmentStudentEntity.getAssessmentEntity().getAssessmentID());
+        assessmentStudentHistoryEntity.setCreateUser(updateUser);
+        assessmentStudentHistoryEntity.setCreateDate(LocalDateTime.now());
+        assessmentStudentHistoryEntity.setUpdateUser(updateUser);
+        assessmentStudentHistoryEntity.setUpdateDate(LocalDateTime.now());
+        return assessmentStudentHistoryEntity;
+    }
+}

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/AssessmentStudentService.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/AssessmentStudentService.java
@@ -2,6 +2,7 @@ package ca.bc.gov.educ.eas.api.service.v1;
 
 import ca.bc.gov.educ.eas.api.exception.EntityNotFoundException;
 import ca.bc.gov.educ.eas.api.model.v1.AssessmentStudentEntity;
+import ca.bc.gov.educ.eas.api.repository.v1.AssessmentStudentHistoryRepository;
 import ca.bc.gov.educ.eas.api.repository.v1.AssessmentStudentRepository;
 import ca.bc.gov.educ.eas.api.struct.v1.AssessmentStudent;
 import ca.bc.gov.educ.eas.api.util.TransformUtil;
@@ -19,11 +20,15 @@ import java.util.UUID;
 public class AssessmentStudentService {
 
     private final AssessmentStudentRepository assessmentStudentRepository;
+    private final AssessmentStudentHistoryRepository assessmentStudentHistoryRepository;
 
+    private final AssessmentStudentHistoryService assessmentStudentHistoryService;
 
     @Autowired
-    public AssessmentStudentService(final AssessmentStudentRepository assessmentStudentRepository) {
+    public AssessmentStudentService(final AssessmentStudentRepository assessmentStudentRepository, AssessmentStudentHistoryRepository assessmentStudentHistoryRepository, AssessmentStudentHistoryService assessmentStudentHistoryService) {
         this.assessmentStudentRepository = assessmentStudentRepository;
+        this.assessmentStudentHistoryRepository = assessmentStudentHistoryRepository;
+        this.assessmentStudentHistoryService = assessmentStudentHistoryService;
     }
 
     public AssessmentStudentEntity getStudentByID(UUID assessmentStudentID) {
@@ -40,12 +45,19 @@ public class AssessmentStudentService {
 
         BeanUtils.copyProperties(assessmentStudentEntity, currentAssessmentStudentEntity, "assessmentEntity", "createUser", "createDate");
         TransformUtil.uppercaseFields(currentAssessmentStudentEntity);
-        return assessmentStudentRepository.save(currentAssessmentStudentEntity);
+        return createAssessmentStudentWithHistory(currentAssessmentStudentEntity);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public AssessmentStudentEntity createStudent(AssessmentStudentEntity assessmentStudentEntity) {
-        return assessmentStudentRepository.save(assessmentStudentEntity);
+        return createAssessmentStudentWithHistory(assessmentStudentEntity);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public AssessmentStudentEntity createAssessmentStudentWithHistory(AssessmentStudentEntity assessmentStudentEntity) {
+        AssessmentStudentEntity savedEntity = assessmentStudentRepository.save(assessmentStudentEntity);
+        assessmentStudentHistoryRepository.save(this.assessmentStudentHistoryService.createAssessmentStudentHistoryEntity(assessmentStudentEntity, assessmentStudentEntity.getUpdateUser()));
+        return savedEntity;
     }
 
 }

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/AssessmentStudentService.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/AssessmentStudentService.java
@@ -45,15 +45,14 @@ public class AssessmentStudentService {
 
         BeanUtils.copyProperties(assessmentStudentEntity, currentAssessmentStudentEntity, "assessmentEntity", "createUser", "createDate");
         TransformUtil.uppercaseFields(currentAssessmentStudentEntity);
-        return this.createAssessmentStudentWithHistory(currentAssessmentStudentEntity);
+        return createAssessmentStudentWithHistory(currentAssessmentStudentEntity);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public AssessmentStudentEntity createStudent(AssessmentStudentEntity assessmentStudentEntity) {
-        return this.createAssessmentStudentWithHistory(assessmentStudentEntity);
+        return createAssessmentStudentWithHistory(assessmentStudentEntity);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
     public AssessmentStudentEntity createAssessmentStudentWithHistory(AssessmentStudentEntity assessmentStudentEntity) {
         AssessmentStudentEntity savedEntity = assessmentStudentRepository.save(assessmentStudentEntity);
         assessmentStudentHistoryRepository.save(this.assessmentStudentHistoryService.createAssessmentStudentHistoryEntity(assessmentStudentEntity, assessmentStudentEntity.getUpdateUser()));

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/AssessmentStudentService.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/AssessmentStudentService.java
@@ -45,12 +45,12 @@ public class AssessmentStudentService {
 
         BeanUtils.copyProperties(assessmentStudentEntity, currentAssessmentStudentEntity, "assessmentEntity", "createUser", "createDate");
         TransformUtil.uppercaseFields(currentAssessmentStudentEntity);
-        return createAssessmentStudentWithHistory(currentAssessmentStudentEntity);
+        return this.createAssessmentStudentWithHistory(currentAssessmentStudentEntity);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public AssessmentStudentEntity createStudent(AssessmentStudentEntity assessmentStudentEntity) {
-        return createAssessmentStudentWithHistory(assessmentStudentEntity);
+        return this.createAssessmentStudentWithHistory(assessmentStudentEntity);
     }
 
     @Transactional(propagation = Propagation.REQUIRED)

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/events/EventHandlerDelegatorService.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/events/EventHandlerDelegatorService.java
@@ -89,6 +89,6 @@ public class EventHandlerDelegatorService {
   }
 
   private void publishToJetStream(final EasEventEntity event) {
-    publisher.dispatchChoreographyEvent(event);
+    //publisher.dispatchChoreographyEvent(event);
   }
 }

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/events/EventHandlerDelegatorService.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/events/EventHandlerDelegatorService.java
@@ -89,6 +89,6 @@ public class EventHandlerDelegatorService {
   }
 
   private void publishToJetStream(final EasEventEntity event) {
-    //publisher.dispatchChoreographyEvent(event);
+    publisher.dispatchChoreographyEvent(event);
   }
 }

--- a/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/events/EventHandlerService.java
+++ b/api/src/main/java/ca/bc/gov/educ/eas/api/service/v1/events/EventHandlerService.java
@@ -70,7 +70,7 @@ public class EventHandlerService {
       log.info(NO_RECORD_SAGA_ID_EVENT_TYPE);
       log.trace(EVENT_PAYLOAD, event);
       AssessmentStudent student = JsonUtil.getJsonObjectFromString(AssessmentStudent.class, event.getEventPayload());
-      val optionalStudent = assessmentStudentRepository.findByAssessmentIDAndStudentID(UUID.fromString(student.getAssessmentID()), student.getStudentID());
+      val optionalStudent = assessmentStudentRepository.findByAssessmentEntity_AssessmentIDAndStudentID(UUID.fromString(student.getAssessmentID()), UUID.fromString(student.getStudentID()));
       easEvent = createAssessmentStudentEventRecord(event);
     } else {
       log.info(RECORD_FOUND_FOR_SAGA_ID_EVENT_TYPE);
@@ -88,7 +88,7 @@ public class EventHandlerService {
   public byte[] handleGetStudentRegistrationEvent(Event event, boolean isSynchronous) throws JsonProcessingException {
     AssessmentStudentGet student = JsonUtil.getJsonObjectFromString(AssessmentStudentGet.class, event.getEventPayload());
     if (isSynchronous) {
-      val optionalStudentEntity = assessmentStudentRepository.findByAssessmentIDAndStudentID(UUID.fromString(student.getAssessmentID()), student.getStudentID());
+      val optionalStudentEntity = assessmentStudentRepository.findByAssessmentEntity_AssessmentIDAndStudentID(UUID.fromString(student.getAssessmentID()), UUID.fromString(student.getStudentID()));
       if (optionalStudentEntity.isPresent()) {
         return JsonUtil.getJsonBytesFromObject(assessmentStudentMapper.toStructure(optionalStudentEntity.get()));
       } else {
@@ -97,7 +97,7 @@ public class EventHandlerService {
     }
 
     log.trace(EVENT_PAYLOAD, event);
-    val optionalStudentEntity = assessmentStudentRepository.findByAssessmentIDAndStudentID(UUID.fromString(student.getAssessmentID()), student.getStudentID());
+    val optionalStudentEntity = assessmentStudentRepository.findByAssessmentEntity_AssessmentIDAndStudentID(UUID.fromString(student.getAssessmentID()), UUID.fromString(student.getStudentID()));
     if (optionalStudentEntity.isPresent()) {
       AssessmentStudent structStud = assessmentStudentMapper.toStructure(optionalStudentEntity.get()); // need to convert to structure MANDATORY otherwise jackson will break.
       event.setEventPayload(JsonUtil.getJsonStringFromObject(structStud));

--- a/api/src/main/resources/db/migration/V1.0.3__EAS.API.sql
+++ b/api/src/main/resources/db/migration/V1.0.3__EAS.API.sql
@@ -1,0 +1,19 @@
+CREATE TABLE ASSESSMENT_STUDENT_HISTORY
+(
+    ASSESSMENT_STUDENT_HISTORY_ID       UUID                                NOT NULL,
+    ASSESSMENT_STUDENT_ID               UUID                                NOT NULL,
+    ASSESSMENT_ID                       UUID                                NOT NULL,
+    SCHOOL_ID                           UUID                                NOT NULL,
+    STUDENT_ID                          UUID                                NOT NULL,
+    PEN                                 VARCHAR(9)                          NOT NULL,
+    LOCAL_ID                            VARCHAR(12),
+    IS_ELECTRONIC_EXAM                  BOOLEAN,
+    FINAL_PERCENTAGE                    VARCHAR(3),
+    PROVINCIAL_SPECIAL_CASE_CODE        VARCHAR(1),
+    COURSE_STATUS_CODE                  VARCHAR(1),
+    CREATE_USER                         VARCHAR(100)                        NOT NULL,
+    CREATE_DATE                         TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    UPDATE_USER                         VARCHAR(100)                        NOT NULL,
+    UPDATE_DATE                         TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT ASSESSMENT_STUDENT_HISTORY_ID_PK PRIMARY KEY (ASSESSMENT_STUDENT_HISTORY_ID)
+);

--- a/api/src/test/java/ca/bc/gov/educ/eas/api/BaseEasAPITest.java
+++ b/api/src/test/java/ca/bc/gov/educ/eas/api/BaseEasAPITest.java
@@ -1,6 +1,5 @@
 package ca.bc.gov.educ.eas.api;
 
-import ca.bc.gov.educ.eas.api.constants.v1.AssessmentTypeCodes;
 import ca.bc.gov.educ.eas.api.model.v1.AssessmentEntity;
 import ca.bc.gov.educ.eas.api.model.v1.AssessmentStudentEntity;
 import ca.bc.gov.educ.eas.api.model.v1.SessionEntity;


### PR DESCRIPTION
Description:
Create history for assessment student entity.

NOTE: PublishToJetStream is commented. This would be addressed as part of EAC-19/EAC-21.

Unit Test cases (Verify History log.:
1. Create student
2. Update student 